### PR TITLE
Adjust error messages and start button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,18 +70,20 @@
               <hr>
             </div>
           </div>
-          <div id="time-error-message" class="warning-message-box hidden">
-            <img id="warning-image" src="./assets/warning.svg">
-            <h2 id="time-warning-phrase" class="warning-phrase"></h2>
-          </div>
           <div id="start-button-box">
-            <button class="activity-window-buttons">START ACTIVITY</button>
+            <div id="time-error-message" class="warning-message-box hidden">
+              <img id="warning-image" src="./assets/warning.svg">
+              <h2 id="time-warning-phrase" class="warning-phrase"></h2>
+            </div>
+            <div id="start-activity-button-wrapper">
+              <button class="activity-window-buttons">START ACTIVITY</button>
+            </div>
           </div>
       </div>
     </section>
     <section id="current-activity-window" class="category-box hidden">
       <div id="current-activity-wrapper">
-        <h2 id="current-activity-description">Deep Breathing</h2>
+        <h2 id="current-activity-description"></h2>
           <div class="timer-message-wrapper">
             <span id="timer"></span>
             <span id="congrats-message" class="hidden">Congrats, you did it!</span>

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ var exerciseRadioBtn = document.querySelector("#Exercise");
 var startActivityBtn = document.querySelector('#start-button-box, .activity-window-buttons');
 var roundBtn = document.querySelector("#round-button");
 var logActivityBtn = document.querySelector("#log-activity-button");
-var createNewActivityBtn = document.querySelector("#create-activity-button")
+var createNewActivityBtn = document.querySelector("#create-activity-button");
 
 var noActivitiesMessage = document.querySelector("#no-activity-message").classList;
 var timeErrorBox = document.querySelector("#time-error-message").classList;
@@ -25,6 +25,8 @@ var radioBtnGrp = document.querySelector('.radio-button-group');
 var warningMessage = document.querySelector(".warning-message-box").classList;
 var cardColorIndicator = document.querySelector(".color-indicator");
 var congratMessage = document.querySelector("#congrats-message").classList;
+var descriptionLine = document.querySelector("#user-activity-inputs hr").style;
+
 var ul = document.querySelector('ul');
 var li = document.createElement('li');
 
@@ -32,7 +34,6 @@ var newActivity;
 var pastActivities = [];
 var isFormCorrect;
 var color;
-var keyNum = 0;
 
 //EVENT LISTENERS
 startActivityBtn.addEventListener('click', submitActivityForm);
@@ -119,7 +120,7 @@ function scanUserFormForErrors() {
   (minuteInput.value.length !== 2 || secondInput.value.length !== 2 || secondInput.value > 59) ? (timeErrorMessage.innerText = errors.error1, timeErrorBox.remove("hidden"))
   : (minuteInput.value.includes(dashSymbol) || secondInput.value.includes(dashSymbol)) ? (timeErrorMessage.innerText = errors.error2, timeErrorBox.remove("hidden"))
   : (minuteInput.value.includes(dotSymbol) || secondInput.value.includes(dotSymbol)) ? (timeErrorMessage.innerText = errors.error2, timeErrorBox.remove("hidden"))
-  : (activityInput.value === "") ? warningMessage.remove("hidden")
+  : (activityInput.value === "") ? (warningMessage.remove("hidden"), descriptionLine.borderColor = "#EFB7EC")
   : (!studyRadioBtn.checked && !meditateRadioBtn.checked && !exerciseRadioBtn.checked) ? (timeErrorMessage.innerText = errors.error3, timeErrorBox.remove("hidden"))
   : isFormCorrect = true;
 
@@ -158,7 +159,7 @@ function displayCurrentActivityWindow() {
 };
 
 function displayCompletedActivityWindow() {
-  noActivitiesMessage.add("hidden")
+  noActivitiesMessage.add("hidden");
   completedActivityTitle.remove("hidden");
   completedActivityView.remove("hidden");
   currentActivityView.add("hidden");
@@ -207,6 +208,7 @@ function clearFormInputs() {
   minuteInput.value = "";
   secondInput.value = "";
   warningMessage.add("hidden");
+  descriptionLine.borderColor = "#CBC9CF";
 };
 
 function returnToMainPage() {

--- a/styles.css
+++ b/styles.css
@@ -54,7 +54,6 @@ margin-right:0.3%;
 
 /* ------New Activity Section------ */
 .activity-window-buttons {
-  margin-top: 5vh;
   height: 5vh;
   width: 25vh;
   border-radius: 0.5vh;
@@ -177,14 +176,26 @@ input[type="text"] {
 
 #start-button-box {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 80%;
   align-items: flex-end;
-  position: relative;
+  position: absolute;
+  margin: 2vh 0;
 }
 
-#time-error-message {
-  height: 4vh;
+#start-activity-button-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: row-reverse;
 }
+
+#time-warning-phrase {
+  margin: 0 0 0 1vh;
+  font-size: 2.2vh;
+  width: 100%;
+}
+
 /* ---Current Activity Section--- */
 #congrats-message {
   font-size: 7vh;
@@ -308,6 +319,7 @@ li {
 
 #log-activity-button {
   width: 34vh;
+  margin-top: 3.5vh;
 }
 
 #no-activity-message {


### PR DESCRIPTION
### What is the change?
Now when users get two error messages on the main page, Start Activity button stays inside the grey block and doesnt move outside of the area. When description error shows up it color the line too according to comp.
Couple syntax adjustments (semicolons)

### What does it fix?
Styling

### Is this a fix or a feature?  
Fix

### Where should the reviewer start?
index.html
line 74-80 - the time error message was move inside the start activity button div 
line 84 -  default description text was removed 

main.js
line 20,28,162 - semicolon adjustment
line 123, 211 - hr style change was added

styles.css
line 57, 322 - margin adj
line 180-198 - new styles for start activity box/button

### How should this be tested?
When description is not entered, user gets an error message which highlights the description line.
When both errors (time and description) appear, start activity button stay inside the new activity window